### PR TITLE
Https fix

### DIFF
--- a/burp-dradis.rb
+++ b/burp-dradis.rb
@@ -182,8 +182,6 @@ class BurpExtender
     label_token  = javax.swing.JLabel.new('API token:')
     label_token.setLabelFor(@field_token)
 
-    @check_ignore_ssl_errors = javax.swing.JCheckBox.new('Ignore SSL certificate errors.')
-
     @field_project_id = javax.swing.JTextField.new()
     @field_project_id.enabled = false
 
@@ -324,18 +322,6 @@ class BurpExtender
     constraints.weightx    = 0
     constraints.weighty    = 0
     panel.add(@field_token, constraints)
-
-    constraints.anchor     = java.awt.GridBagConstraints::NORTH
-    constraints.fill       = java.awt.GridBagConstraints::BOTH
-    constraints.gridx      = 1
-    constraints.gridy      = 5
-    constraints.gridwidth  = 4
-    constraints.gridheight = 1
-    constraints.insets     = java.awt.Insets.new(5,10,5,5)
-    constraints.weightx    = 0
-    constraints.weighty    = 0
-    panel.add(@check_ignore_ssl_errors, constraints)
-
 
     constraints.anchor     = java.awt.GridBagConstraints::EAST
     constraints.fill       = java.awt.GridBagConstraints::VERTICAL
@@ -547,7 +533,6 @@ class BurpExtender
   def save_settings
     @callbacks.save_extension_setting 'edition', @radio_ce.selected ? 'ce' : 'pro'
     @callbacks.save_extension_setting 'endpoint', @field_endpoint.text
-    @callbacks.save_extension_setting 'ignore_ssl_errors', @check_ignore_ssl_errors.selected ? 'true' : 'false'
     @callbacks.save_extension_setting 'path', @field_path.text
     @callbacks.save_extension_setting 'project_id', @field_project_id.text
     @callbacks.save_extension_setting 'token', @field_token.text
@@ -598,8 +583,6 @@ class BurpExtender
 
     edition == 'ce' ? @radio_ce.selected = true : @radio_pro.selected = true
     toggle_edition()
-
-    @check_ignore_ssl_errors.selected = ignore_ssl_errors == 'true' ? true : false
 
     @stdout.println 'Configuration restored.'
   end

--- a/burp-dradis.rb
+++ b/burp-dradis.rb
@@ -383,13 +383,14 @@ class BurpExtender
     container
   end
 
-  # Internal: builds a Thread object that makes an HTTP request using the Burp API
+  # Internal: builds a an HTTP POST request with headers containing
+  # authentication and payload.
   #
-  # endpoint - The configured Dradis endpoint
-  # token - The configured Dradis API token
+  # uri     - The URI that we'll use to build the request's Host and path.
+  # token   - The configured Dradis API token (Pro) or shared password (CE).
   # payload - The HTTP request body to be sent
   #
-  # Returns a Thread object
+  # Returns a string containing a valid HTTP POST require request.
   #
   def build_http_request(uri, token, payload)
     host = uri.host
@@ -555,8 +556,10 @@ class BurpExtender
 
 
   # Internal: Open a Java thread and send the request through the wire using
-  # Burp's standard API for http messaging.
+  # Burp's standard API for http messaging. We need a thread because Burp
+  # doesn't like in-line requests that could freeze the UI.
   #
+  # uri     - An URI object so we know where to send the request to
   # request - The HTTP request message we want to send to the server.
   #
   # Returns nothing.

--- a/burp-dradis.rb
+++ b/burp-dradis.rb
@@ -65,7 +65,7 @@ class BurpExtender
   module META
     NAME        = 'Dradis Framework connector'
     TAB_CAPTION = 'Dradis Framework'
-    VERSION     = '0.0.2'
+    VERSION     = '0.0.3'
   end
 
 


### PR DESCRIPTION
[Trello](https://trello.com/c/lRuQbBBZ/274-3-when-use-the-burp-suite-i-want-to-send-an-issue-to-the-dradis-server-through-https-so-i-can-seamlessly-use-burp-with-dradis)

- Replaced ruby's `Net::HTTP` with Burp API