### PR TITLE
Add accept header and bump version to 0.0.4

### DIFF
--- a/burp-dradis.rb
+++ b/burp-dradis.rb
@@ -62,7 +62,7 @@ class BurpExtender
   module META
     NAME        = 'Dradis Framework connector'
     TAB_CAPTION = 'Dradis Framework'
-    VERSION     = '0.0.3'
+    VERSION     = '0.0.4'
   end
 
 
@@ -403,6 +403,7 @@ class BurpExtender
     request = []
     request << "POST #{path} HTTP/1.1"
     request << "Host: #{host}"
+    request << 'Accept: */*'
     request << "Content-Type: application/json"
     request << "Content-Length: #{payload.bytesize}"
 


### PR DESCRIPTION
### Summary

With the introduction of API v3 in Dradis v4.10.0, the endpoints now expect an `Accept` header to fetch the requested API version. When building a request to send to Dradis from burp, the `Accept` header is missing, causing the server to throw an error instead.

*Proposed solution*
Add an `Accept: */*` header to the request.